### PR TITLE
Implement modularity in the form of subexpressions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,25 @@
 // Type definitions for Super Expressive 1.0.0
 // Project: https://github.com/francisrstokes/super-expressive/
-// Definitions by: Jimmy Affatigato <https://github.com/jimmyaffatigato/>
+// Definitions by:
+//  - Jimmy Affatigato <https://github.com/jimmyaffatigato/>
+//  - Francis Stokes <https://github.com/francisrstokes/
+
+declare type SubexpressionOptions = {
+    /**
+     * Namespace to use on all named capture groups in the subexpression, to avoid naming collisions with your own named groups
+     */
+    namespace?: string;
+
+    /**
+     * If set to true, any flags this subexpression specifies should be disregarded
+     */
+    ignoreFlags?: boolean;
+
+    /**
+     * If set to true, any startOfInput/endOfInput asserted in this subexpression specifies should be disregarded
+     */
+    ignoreStartAndEnd?: boolean;
+}
 
 declare class SuperExpressive {
     /**
@@ -238,10 +257,20 @@ declare class SuperExpressive {
     range(a: string, b: string): SuperExpressive;
 
     /**
+     * Matches another SuperExpressive instance.
+     * @param {SuperExpressive} expr
+     * @param {SubexpressionOptions} opts
+     * @param {string} opts.namespace - default = ''
+     * @param {boolean} opts.ignoreFlags - default = true
+     * @param {boolean} opts.ignoreStartAndEnd - default = true
+     */
+    subexpression(expr: SuperExpressive, opts?: SubexpressionOptions): SuperExpressive;
+
+    /**
      * Outputs a string representation of the regular expression that this SuperExpression models.
      */
     toRegexString(): string;
-    
+
     /**
      * Outputs the regular expression that this SuperExpression models.
      */

--- a/index.js
+++ b/index.js
@@ -436,7 +436,7 @@ class SuperExpressive {
     const elementValue = t.range([strA, strB]);
     const currentFrame = next[getCurrentFrame]();
 
-    currentFrame.elements.push(this[applyQuantifier](elementValue));
+    currentFrame.elements.push(next[applyQuantifier](elementValue));
 
     return next;
   }

--- a/index.js
+++ b/index.js
@@ -459,11 +459,11 @@ class SuperExpressive {
     );
 
     const pattern = this[getCurrentElementArray]().map(SuperExpressive[evaluate]).join('');
-    const flags = Object.entries(this.state.flags).map(([name, isOn]) => isOn ? name : '').join('');
+    const flags = Object.entries(this.state.flags).map(([name, isOn]) => isOn ? name : '');
 
     return {
       pattern: pattern === '' ? '(?:)' : pattern,
-      flags
+      flags: flags.sort().join('')
     };
   }
 

--- a/index.js
+++ b/index.js
@@ -44,22 +44,24 @@ const quantifierTable = {
   betweenLazy: metadata => `{${metadata[0]},${metadata[1]}}?`,
 }
 
+const applySubexpressionDefaults = expr => {
+  const out = { ...expr };
+  out.namespace = ('namespace' in out) ? out.namespace : '';
+  out.ignoreFlags = ('ignoreFlags' in out) ? out.ignoreFlags : true;
+  out.ignoreStartAndEnd = ('ignoreStartAndEnd' in out) ? out.ignoreStartAndEnd : true;
+
+  assert(typeof out.namespace === 'string', 'namespace must be a string');
+  assert(typeof out.ignoreFlags === 'boolean', 'ignoreFlags must be a boolean');
+  assert(typeof out.ignoreStartAndEnd === 'boolean', 'ignoreStartAndEnd must be a boolean');
+
+  return out;
+}
+
 const t = {
   root: asType('root') (),
+  noop: asType('noop') (),
   startOfInput: asType('startOfInput') (),
   endOfInput: asType('endOfInput') (),
-  capture: deferredType('capture'),
-  namedCapture: name => deferredType('namedCapture', { metadata: name }),
-  namedBackreference: name => deferredType('namedBackreference', { metadata: name }),
-  backreference: index => deferredType('backreference', { metadata: index }),
-  group: deferredType('group'),
-  anyOf: deferredType('anyOf'),
-  assertAhead: deferredType('assertAhead'),
-  assertNotAhead: deferredType('assertNotAhead'),
-  exactly: times => deferredType('exactly', { metadata: times }),
-  atLeast: times => deferredType('atLeast', { metadata: times }),
-  between: (x, y) => deferredType('between', { metadata: [x, y] }),
-  betweenLazy: (x, y) => deferredType('betweenLazy', { metadata: [x, y] }),
   anyChar: asType('anyChar') (),
   whitespaceChar: asType('whitespaceChar') (),
   nonWhitespaceChar: asType('nonWhitespaceChar') (),
@@ -73,18 +75,31 @@ const t = {
   carriageReturn: asType('carriageReturn') (),
   tab: asType('tab') (),
   nullByte: asType('nullByte') (),
-  string: asType('string', { quantifierRequiresGroup: true }),
   anyOfChars: asType('anyOfChars'),
   anythingButString: asType('anythingButString'),
   anythingButChars: asType('anythingButChars'),
   anythingButRange: asType('anythingButRange'),
   char: asType('char'),
   range: asType('range'),
-  zeroOrMore: deferredType('zeroOrMore'),
-  zeroOrMoreLazy: deferredType('zeroOrMoreLazy'),
-  oneOrMore: deferredType('oneOrMore'),
-  oneOrMoreLazy: deferredType('oneOrMoreLazy'),
-  optional: deferredType('optional'),
+  string: asType('string', { quantifierRequiresGroup: true }),
+  namedBackreference: name => deferredType('namedBackreference', { metadata: name }),
+  backreference: index => deferredType('backreference', { metadata: index }),
+  capture: deferredType('capture', { containsChildren: true }),
+  subexpression: asType('subexpression', { containsChildren: true, quantifierRequiresGroup: true }),
+  namedCapture: name => deferredType('namedCapture', { metadata: name, containsChildren: true }),
+  group: deferredType('group', { containsChildren: true }),
+  anyOf: deferredType('anyOf', { containsChildren: true }),
+  assertAhead: deferredType('assertAhead', { containsChildren: true }),
+  assertNotAhead: deferredType('assertNotAhead', { containsChildren: true }),
+  exactly: times => deferredType('exactly', { metadata: times, containsChild: true }),
+  atLeast: times => deferredType('atLeast', { metadata: times, containsChild: true }),
+  between: (x, y) => deferredType('between', { metadata: [x, y], containsChild: true }),
+  betweenLazy: (x, y) => deferredType('betweenLazy', { metadata: [x, y], containsChild: true }),
+  zeroOrMore: deferredType('zeroOrMore', { containsChild: true }),
+  zeroOrMoreLazy: deferredType('zeroOrMoreLazy', { containsChild: true }),
+  oneOrMore: deferredType('oneOrMore', { containsChild: true }),
+  oneOrMoreLazy: deferredType('oneOrMoreLazy', { containsChild: true }),
+  optional: deferredType('optional', { containsChild: true }),
 }
 
 const isFusable = element => {
@@ -121,6 +136,8 @@ const getRegexPatternAndFlags = Symbol('getRegexBody');
 const matchElement = Symbol('matchElement');
 const frameCreatingElement = Symbol('frameCreatingElement');
 const quantifierElement = Symbol('quantifierElement');
+const mergeSubexpression = Symbol('mergeSubexpression');
+const trackNamedGroup = Symbol('trackNamedGroup');
 
 class SuperExpressive {
   constructor() {
@@ -235,15 +252,19 @@ class SuperExpressive {
     return next;
   }
 
-  namedCapture(name) {
+  [trackNamedGroup](name) {
     assert(typeof name === 'string', `name must be a string (got ${name})`);
     assert(name.length > 0, `name must be at least one character`);
     assert(!this.state.namedGroups.includes(name), `cannot use ${name} again for a capture group`);
-    assert(namedGroupRegex.test(name), `name is not valid (only letters, numbers, and underscores)`);
+    assert(namedGroupRegex.test(name), `name "${name}" is not valid (only letters, numbers, and underscores)`);
+    this.state.namedGroups.push(name);
+  }
 
+  namedCapture(name) {
     const next = this[clone]();
     const newFrame = createStackFrame(t.namedCapture(name));
-    next.state.namedGroups.push(name);
+
+    next[trackNamedGroup](name);
     next.state.stack.push(newFrame);
     next.state.totalCaptureGroups++;
     return next;
@@ -441,6 +462,125 @@ class SuperExpressive {
     return next;
   }
 
+  static [mergeSubexpression](el, options, parent, incrementCaptureGroups) {
+    let nextEl = deepCopy(el);
+
+    if (nextEl.type === 'backreference') {
+      nextEl.metadata += parent.state.totalCaptureGroups;
+    }
+
+    if (nextEl.type === 'capture') {
+      incrementCaptureGroups();
+    }
+
+    if (nextEl.type === 'namedCapture') {
+      const groupName = options.namespace
+        ? `${options.namespace}${nextEl.metadata}`
+        : nextEl.metadata;
+
+      parent[trackNamedGroup](groupName);
+      nextEl.metadata = groupName;
+    }
+
+    if (nextEl.type === 'namedBackreference') {
+      nextEl.metadata = options.namespace
+        ? `${options.namespace}${nextEl.metadata}`
+        : nextEl.metadata;
+    }
+
+    if (nextEl.containsChild) {
+      nextEl.value = SuperExpressive[mergeSubexpression](
+        nextEl.value,
+        options,
+        parent,
+        incrementCaptureGroups
+      );
+    } else if (nextEl.containsChildren) {
+      nextEl.value = nextEl.value.map(e =>
+        SuperExpressive[mergeSubexpression](
+          e,
+          options,
+          parent,
+          incrementCaptureGroups
+        )
+      );
+    }
+
+    if (nextEl.type === 'startOfInput') {
+      if (options.ignoreStartAndEnd) {
+        return t.noop;
+      }
+
+      assert(
+        !parent.state.hasDefinedStart,
+        'The parent regex already has a defined start of input. ' +
+        'You can ignore a subexpressions startOfInput/endOfInput markers with the ignoreStartAndEnd option'
+      );
+
+      assert(
+        !parent.state.hasDefinedEnd,
+        'The parent regex already has a defined end of input. ' +
+        'You can ignore a subexpressions startOfInput/endOfInput markers with the ignoreStartAndEnd option'
+      );
+
+      parent.state.hasDefinedStart = true;
+    }
+
+    if (nextEl.type === 'endOfInput') {
+      if (options.ignoreStartAndEnd) {
+        return t.noop;
+      }
+
+      assert(
+        !parent.state.hasDefinedEnd,
+        'The parent regex already has a defined start of input. ' +
+        'You can ignore a subexpressions startOfInput/endOfInput markers with the ignoreStartAndEnd option'
+      );
+
+      parent.state.hasDefinedEnd = true;
+    }
+
+    return nextEl;
+  }
+
+  subexpression(expr, opts = {}) {
+    assert(expr instanceof SuperExpressive, `expr must be a SuperExpressive instance`);
+    assert(
+      expr.state.stack.length === 1,
+      'Cannot call subexpression with a not yet fully specified regex object.' +
+      `\n(Try adding a .end() call to match the "${expr[getCurrentFrame]().type.type}" on the subexpression)\n`
+    );
+
+    const options = applySubexpressionDefaults(opts);
+
+    const exprNext = expr[clone]();
+    const next = this[clone]();
+    let additionalCaptureGroups = 0;
+
+    const exprFrame = exprNext[getCurrentFrame]();
+    exprFrame.elements = exprFrame.elements.map(e =>
+      SuperExpressive[mergeSubexpression](
+        e,
+        options,
+        next,
+        () => additionalCaptureGroups++
+      )
+    );
+
+    next.state.totalCaptureGroups += additionalCaptureGroups;
+
+    if (!options.ignoreFlags) {
+      Object.entries(exprNext.state.flags).forEach(([flagName, enabled]) => {
+        next.state.flags[flagName] = enabled || next.state.flags[flagName];
+      });
+    }
+
+    const currentFrame = next[getCurrentFrame]();
+    currentFrame.elements.push(next[applyQuantifier](t.subexpression(exprFrame.elements)));
+
+    return next;
+  }
+
   toRegexString() {
     const {pattern, flags} = this[getRegexPatternAndFlags]();
     return `/${pattern}/${flags}`;
@@ -493,6 +633,7 @@ class SuperExpressive {
 
   static [evaluate](el) {
     switch (el.type) {
+      case 'noop': return '';
       case 'anyChar': return '.';
       case 'whitespaceChar': return '\\s';
       case 'nonWhitespaceChar': return '\\S';
@@ -516,6 +657,7 @@ class SuperExpressive {
       case 'anythingButChars': return `[^${el.value}]`;
       case 'namedBackreference': return `\\k<${el.metadata}>`;
       case 'backreference': return `\\${el.metadata}`;
+      case 'subexpression': return el.value.map(SuperExpressive[evaluate]).join('');
 
       case 'optional':
       case 'zeroOrMore':

--- a/index.test.js
+++ b/index.test.js
@@ -108,7 +108,7 @@ describe('SuperExpressive', () => {
 
   testErrorConditition(
     'namedCapture error on bad name',
-    'name is not valid (only letters, numbers, and underscores)',
+    'name "hello world" is not valid (only letters, numbers, and underscores)',
     () => SuperExpressive()
       .namedCapture('hello world')
         .string('hello ')
@@ -230,7 +230,199 @@ describe('SuperExpressive', () => {
   );
 
   testRegexEquality('range', /[a-z]/, SuperExpressive().range('a', 'z'));
+});
 
+describe('subexpressions', () => {
+  testErrorConditition(
+    'subexpression(expr): expr must be a SuperExpressive instance',
+    'expr must be a SuperExpressive instance',
+    () => SuperExpressive().subexpression('nope')
+  )
 
+  const simpleSubExpression = SuperExpressive()
+    .string('hello')
+    .anyChar
+    .string('world');
 
+  testRegexEquality(
+    'simple',
+    /^\d{3,}hello.world[0-9]$/,
+    SuperExpressive()
+      .startOfInput
+      .atLeast(3).digit
+      .subexpression(simpleSubExpression)
+      .range('0', '9')
+      .endOfInput
+  );
+
+  testRegexEquality(
+    'simple: quantified',
+    /^\d{3,}(?:hello.world)+[0-9]$/,
+    SuperExpressive()
+      .startOfInput
+      .atLeast(3).digit
+      .oneOrMore.subexpression(simpleSubExpression)
+      .range('0', '9')
+      .endOfInput
+  );
+
+  const flagsSubExpression = SuperExpressive()
+    .allowMultipleMatches
+    .unicode
+    .lineByLine
+    .caseInsensitive
+    .string('hello')
+    .anyChar
+    .string('world');
+
+  testRegexEquality(
+    'ignoring flags = false',
+    /^\d{3,}hello.world[0-9]$/gymiu,
+    SuperExpressive()
+      .sticky
+      .startOfInput
+      .atLeast(3).digit
+      .subexpression(flagsSubExpression, { ignoreFlags: false })
+      .range('0', '9')
+      .endOfInput
+  );
+
+  testRegexEquality(
+    'ignoring flags = true',
+    /^\d{3,}hello.world[0-9]$/y,
+    SuperExpressive()
+      .sticky
+      .startOfInput
+      .atLeast(3).digit
+      .subexpression(flagsSubExpression)
+      .range('0', '9')
+      .endOfInput
+  );
+
+  const startEndSubExpression = SuperExpressive()
+    .startOfInput
+    .string('hello')
+    .anyChar
+    .string('world')
+    .endOfInput;
+
+  testRegexEquality(
+    'ignoring start/end = false',
+    /\d{3,}^hello.world$[0-9]/,
+    SuperExpressive()
+      .atLeast(3).digit
+      .subexpression(startEndSubExpression, { ignoreStartAndEnd: false })
+      .range('0', '9')
+  );
+
+  testRegexEquality(
+    'ignoring start/end = true',
+    /\d{3,}hello.world[0-9]/,
+    SuperExpressive()
+      .atLeast(3).digit
+      .subexpression(startEndSubExpression)
+      .range('0', '9')
+  );
+
+  testErrorConditition(
+    'start defined in subexpression and main expression',
+    'The parent regex already has a defined start of input. You can ignore a subexpressions startOfInput/endOfInput markers with the ignoreStartAndEnd option',
+    () => SuperExpressive()
+      .startOfInput
+      .atLeast(3).digit
+      .subexpression(startEndSubExpression, { ignoreStartAndEnd: false })
+      .range('0', '9')
+  );
+
+  testErrorConditition(
+    'end defined in subexpression and main expression',
+    'The parent regex already has a defined end of input. You can ignore a subexpressions startOfInput/endOfInput markers with the ignoreStartAndEnd option',
+    () => SuperExpressive()
+      .endOfInput
+      .subexpression(startEndSubExpression, { ignoreStartAndEnd: false })
+  );
+
+  const namedCaptureSubExpression = SuperExpressive()
+    .namedCapture('module')
+      .exactly(2).anyChar
+    .end()
+    .namedBackreference('module');
+
+  testRegexEquality(
+    'no namespacing',
+    /\d{3,}(?<module>.{2})\k<module>[0-9]/,
+    SuperExpressive()
+      .atLeast(3).digit
+      .subexpression(namedCaptureSubExpression)
+      .range('0', '9')
+  );
+
+  testRegexEquality(
+    'namespacing',
+    /\d{3,}(?<yolomodule>.{2})\k<yolomodule>[0-9]/,
+    SuperExpressive()
+      .atLeast(3).digit
+      .subexpression(namedCaptureSubExpression, { namespace: 'yolo' })
+      .range('0', '9')
+  );
+
+  testErrorConditition(
+    'group name collision (no namespacing)',
+    'cannot use module again for a capture group',
+    () => SuperExpressive()
+      .namedCapture('module')
+        .atLeast(3).digit
+      .end()
+      .subexpression(namedCaptureSubExpression)
+      .range('0', '9')
+  );
+
+  testErrorConditition(
+    'group name collision (after namespacing)',
+    'cannot use yolomodule again for a capture group',
+    () => SuperExpressive()
+      .namedCapture('yolomodule')
+        .atLeast(3).digit
+      .end()
+      .subexpression(namedCaptureSubExpression, { namespace: 'yolo' })
+      .range('0', '9')
+  );
+
+  const indexedBackreferenceSubexpression = SuperExpressive()
+    .capture
+    .exactly(2).anyChar
+    .end()
+    .backreference(1);
+
+  testRegexEquality(
+    'indexed backreferencing',
+    /(\d{3,})(.{2})\2\1[0-9]/,
+    SuperExpressive()
+      .capture
+        .atLeast(3).digit
+      .end()
+      .subexpression(indexedBackreferenceSubexpression)
+      .backreference(1)
+      .range('0', '9')
+  );
+
+  const nestedSubexpression = SuperExpressive().exactly(2).anyChar;
+  const firstLayerSubexpression = SuperExpressive()
+    .string('outer begin')
+    .namedCapture('innerSubExpression')
+      .optional.subexpression(nestedSubexpression)
+    .end()
+    .string('outer end');
+
+  testRegexEquality(
+    'deeply nested subexpressions',
+    /(\d{3,})outer begin(?<innerSubExpression>(?:.{2})?)outer end\1[0-9]/,
+    SuperExpressive()
+      .capture
+        .atLeast(3).digit
+      .end()
+      .subexpression(firstLayerSubexpression)
+      .backreference(1)
+      .range('0', '9')
+  );
 });

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ![Super Expressive Logo](./logo.png)
 
-**Super Expressive** is a JavaScript library that allows you to build regular expressions in almost natural language - with no extra dependencies, and a lightweight code footprint (less than 3kb with minification + gzip!).
+**Super Expressive** is a JavaScript library that allows you to build regular expressions in almost natural language - with no extra dependencies, and a lightweight code footprint (less than 4kb with minification + gzip!).
 
 ---
 
@@ -60,6 +60,7 @@
   - [.string(s)](#string(s))
   - [.char(c)](#char(c))
   - [.range(a, b)](#range(a,-b))
+  - [.subexpression(expr, opts)](#subexpression(expr,-opts))
   - [.toRegexString()](#toRegexString())
   - [.toRegex()](#toRegex())
   </details>
@@ -766,6 +767,29 @@ SuperExpressive()
 // ->
 /[a-z]/
 ```
+
+### .subexpression(expr, opts?)
+
+- *opts.namespace*: A **string** namespace to use on all named capture groups in the subexpression, to avoid naming collisions with your own named groups (default = `''`)
+- *opts.ignoreFlags*: If set to true, any flags this subexpression specifies should be disregarded (default = `true`)
+- *opts.ignoreStartAndEnd*: If set to true, any startOfInput/endOfInput asserted in this subexpression specifies should be disregarded (default = `true`)
+
+Matches another SuperExpressive instance inline. Can be used to create libraries, or to modularise you code. By default, flags and start/end of input markers are ignored, but can be explcitly turned on in the options object.
+
+**Example**
+```JavaScript
+// A reusable SuperExpressive...
+const fiveDigits = SuperExpressive().exactly(5).digit;
+
+SuperExpressive()
+  .oneOrMore.range('a', 'z')
+  .atLeast(3).anyChar
+  .subexpression(fiveDigits)
+  .toRegex();
+// ->
+/[a-z]+.{3,}(?:\d{5})/
+```
+
 
 ### .toRegexString()
 


### PR DESCRIPTION
<!--

Thanks for taking an interest in this project, and the time to open a pull request!
Please use the following checklist to guide the process. If the checklist isn't able to fully convey your
intentions then feel free to leave elaboration comments below!

-->

## Implement modularity in the form of subexpressions

This PR addresses issue #12. It was a little complex to implement, because there are some edge cases to look out for when merging one SuperExpressive instance with another. These came primarily in the form of dealing with flags, start/end of input markers, named capture group naming collisions, backreference indexing, and deep levels of nesting.

I've added a set of tests which I think cover these edge cases acceptably.

- [ ] This PR  only introduces changes to documentation.
  - Please include a summary of changes and an explanation
- [x] This PR adds new functionality
  - [x] Is there a related issue?
    - Please note the related issue below, and how this PR relates to the issue if appropriate
  - [x] Does the code style reasonably match the existing code?
  - [x] Are the changes tested (using the existing format, as far as is possible?)
  - [x] Are the changes documented in the readme with a suitable example?
  - [x] Is the table of contents updated?
  - [x] Is the `index.d.ts` file updated, using appropriate types and using the same description as the readme?
- [ ] This PR introduces some other kind of change
  - Please explain the change below