### PR TITLE
It is considered best practice to use import

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@
 - [Why](#Why)
 - [Installation and Usage](#Installation-and-Usage)
 - [Example](#Example)
+- [Example with Create React App](#Example-with-Create-React-App)
 - [API](#API)
   <details>
     <summary>Click to expand</summary>
@@ -108,6 +109,28 @@ const myRegex = SuperExpressive()
 
 // Produces the following regular expression:
 /^(?:0x)?([A-Fa-f0-9]{4})$/
+```
+
+## Example with Create React App
+
+```
+import SuperExpressive from 'super-expressive';
+
+const myRegex = SuperExpressive()
+  .startOfInput.optional.string('0x')
+  .capture.exactly(4)
+  .anyOf.range('A', 'F')
+  .range('a', 'f')
+  .range('0', '9')
+  .end()
+  .end()
+  .endOfInput.toRegex();
+
+function App() {
+  return <div className="App">{myRegex.toString()}</div>;
+}
+
+export default App;
 ```
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ const myRegex = SuperExpressive()
 
 ## Example with Create React App
 
-```
+```javascript
 import SuperExpressive from 'super-expressive';
 
 const myRegex = SuperExpressive()


### PR DESCRIPTION
## It is considered best practice to use import instead of require in React and ES6

- [x] This PR  only introduces changes to documentation.

It is considered best practice to use import instead of require in React and ES6, which is why it could be nice to include an example with React and ES6 import.

Mixing import and require is a bad practice, which is why I thought it would be good to include a simple example using Create React App, which could be handy for React beginners (or people experienced with React).

  - [x] Does the code style reasonably match the existing code?
  - [x] Are the changes tested (using the existing format, as far as is possible?)
  - [x] Are the changes documented in the readme with a suitable example?
  - [x] Is the table of contents updated?