### PR TITLE
Bugfix: Add special character escaping for strings of length one

### DIFF
--- a/index.js
+++ b/index.js
@@ -427,7 +427,7 @@ class SuperExpressive {
     assert(s.length >= 0, `s cannot be an empty string`);
 
     const next = this[clone]();
-    const elementValue = s.length > 1 ? t.string(escapeSpecial(s)) : t.char(s);
+    const elementValue = s.length > 1 ? t.string(escapeSpecial(s)) : t.char(escapeSpecial(s));
     const currentFrame = next[getCurrentFrame]();
     currentFrame.elements.push(next[applyQuantifier](elementValue));
 

--- a/index.test.js
+++ b/index.test.js
@@ -242,6 +242,7 @@ describe('SuperExpressive', () => {
   testRegexEquality('anythingButChars', /[^aeiou\.\-]/, SuperExpressive().anythingButChars('aeiou.-'));
   testRegexEquality('anythingButRange', /[^0-9]/, SuperExpressive().anythingButRange('0', '9'));
   testRegexEquality('string', /hello/, SuperExpressive().string('hello'));
+  testRegexEquality('string escapes special characters with strings of length 1', /\^hello/ ,SuperExpressive().string('^').string('hello'))
   testRegexEquality('char', /h/, SuperExpressive().string('h'));
   testErrorConditition(
     'char: more than one',


### PR DESCRIPTION
## Bugfix: Add special character escaping for strings of length one

- [ ] This PR  only introduces changes to documentation.
  - Please include a summary of changes and an explanation
- [ ] This PR adds new functionality
  - [ ] Is there a related issue?
    - Please note the related issue below, and how this PR relates to the issue if appropriate
  - [ ] Does the code style reasonably match the existing code?
  - [ ] Are the changes tested (using the existing format, as far as is possible?)
  - [ ] Are the changes documented in the readme with a suitable example?
  - [ ] Is the table of contents updated?
  - [ ] Is the `index.d.ts` file updated, using appropriate types and using the same description as the readme?
- [x] This PR introduces some other kind of change

This is a fix to, what I assume, to be a bug. If you used the `string` function with length one, then special characters were not escaped. This was at least unexpected to me. The `char` function did escape it. 