### PR TITLE
allOf: now fuses character classes like \d

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,24 +69,24 @@ const t = {
   startOfInput: asType('startOfInput') (),
   endOfInput: asType('endOfInput') (),
   anyChar: asType('anyChar') (),
-  whitespaceChar: asType('whitespaceChar') (),
-  nonWhitespaceChar: asType('nonWhitespaceChar') (),
-  digit: asType('digit') (),
-  nonDigit: asType('nonDigit') (),
-  word: asType('word') (),
-  nonWord: asType('nonWord') (),
+  whitespaceChar: asType('whitespaceChar', { classCompatible: true }) (),
+  nonWhitespaceChar: asType('nonWhitespaceChar', { classCompatible: true }) (),
+  digit: asType('digit', { classCompatible: true }) (),
+  nonDigit: asType('nonDigit', { classCompatible: true }) (),
+  word: asType('word', { classCompatible: true }) (),
+  nonWord: asType('nonWord', { classCompatible: true }) (),
   wordBoundary: asType('wordBoundary') (),
   nonWordBoundary: asType('nonWordBoundary') (),
-  newline: asType('newline') (),
-  carriageReturn: asType('carriageReturn') (),
-  tab: asType('tab') (),
-  nullByte: asType('nullByte') (),
-  anyOfChars: asType('anyOfChars'),
+  newline: asType('newline',{ classCompatible: true }) (),
+  carriageReturn: asType('carriageReturn', { classCompatible: true }) (),
+  tab: asType('tab', { classCompatible: true }) (),
+  nullByte: asType('nullByte', { classCompatible: true }) (),
+  anyOfChars: asType('anyOfChars', { classCompatible: true }),
   anythingButString: asType('anythingButString'),
   anythingButChars: asType('anythingButChars'),
   anythingButRange: asType('anythingButRange'),
-  char: asType('char'),
-  range: asType('range'),
+  char: asType('char', { classCompatible: true }),
+  range: asType('range', { classCompatible: true }),
   string: asType('string', { quantifierRequiresGroup: true }),
   namedBackreference: name => deferredType('namedBackreference', { name }),
   backreference: index => deferredType('backreference', { index }),
@@ -111,15 +111,15 @@ const t = {
 }
 
 const isFusable = element => {
-  return element.type === 'range' ||
-    element.type === 'char' ||
-    element.type === 'anyOfChars';
+  return element.classCompatible;
 };
 const fuseElements = elements => {
   const [fusables, rest] = partition(isFusable, elements);
   const fused = fusables.map(el => {
     if (el.type === 'char' || el.type === 'anyOfChars') {
       return el.value;
+    } else if (el.type !== 'range') {
+      return SuperExpressive[evaluate](el);
     }
     return `${el.value[0]}-${el.value[1]}`;
   }).join('');

--- a/index.test.js
+++ b/index.test.js
@@ -46,7 +46,7 @@ describe('SuperExpressive', () => {
 
   testRegexEquality(
     'anyOf: basic',
-    /(?:hello|\d|\w|[\.#])/,
+    /(?:hello|[\d\w\.#])/,
     SuperExpressive()
       .anyOf
         .string('hello')


### PR DESCRIPTION
<!--

Thanks for taking an interest in this project, and the time to open a pull request!
Please use the following checklist to guide the process. If the checklist isn't able to fully convey your
intentions then feel free to leave elaboration comments below!

-->

## Changes `allOf` to fuse classes like `\d`, `\w`, `\S`, etc, into a single `[]` class.

- [ ] This PR  only introduces changes to documentation.
  - Please include a summary of changes and an explanation
- [x] This PR adds new functionality
  - [ ] Is there a related issue?
    - Please note the related issue below, and how this PR relates to the issue if appropriate
  - [x] Does the code style reasonably match the existing code?
  - [x] Are the changes tested (using the existing format, as far as is possible?)
  - [ ] Are the changes documented in the readme with a suitable example?
  - [ ] Is the table of contents updated?
  - [ ] Is the `index.d.ts` file updated, using appropriate types and using the same description as the readme?
- [ ] This PR introduces some other kind of change
  - Please explain the change below

This commit adds an extra flag to every command that outputs values that are compatible with `[]` character classes. This allows the `fuseElements` and `isFusable` functions to intelligently fuse the results of methods like `whitespaceChars` with `range` into a single `[\sa-b]` expression.

I only needed to change one of the test cases for this new behaviour. I am not sure if anything would need to be changed in the documentation.