### PR TITLE
Add support for all missing Regex character classes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -113,6 +113,21 @@ declare class SuperExpressive {
     tab: SuperExpressive;
 
     /**
+     * Matches a `\v` character.
+     */
+    verticalTab: SuperExpressive;
+
+    /**
+     * Matches a `\f` character.
+     */
+    formFeed: SuperExpressive;
+
+    /**
+     * Matches a `\b` character.
+     */
+    backspace: SuperExpressive;
+
+    /**
      * Matches a `\u0000` character (ASCII `0`).
      */
     nullByte: SuperExpressive;

--- a/index.d.ts
+++ b/index.d.ts
@@ -277,6 +277,11 @@ declare class SuperExpressive {
     char(c: string): SuperExpressive;
 
     /**
+     * Matches a control code for the latin character `c`.
+     */
+    controlChar(c: string): SuperExpressive;
+
+    /**
      * Matches any character that falls between `a` and `b`. Ordering is defined by a characters ASCII or unicode value.
      */
     range(a: string, b: string): SuperExpressive;

--- a/index.d.ts
+++ b/index.d.ts
@@ -294,6 +294,33 @@ declare class SuperExpressive {
     utf16Code(hex: string): SuperExpressive;
 
     /**
+     * Matches a unicode character with the value `hex`.
+     * Enables the unicode `u` flag when used.
+     * @param hex A 4 or 5 digit hexadecimal string.
+     */
+    unicodeCharCode(hex: string): SuperExpressive;
+
+    /**
+     * Matches a Unicode character with the given Unicode property.
+     * Invalid Unicode properties or values will cause .toRegex() to throw an error.
+     * Enables the unicode `u` flag when used.
+     * @param property A Unicode character property in the form `loneProperty` or `property=value`.
+     * For valid properties see the MDN Docs:
+     * https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape
+     */
+    unicodeProperty(property: string): SuperExpressive;
+
+    /**
+     * Matches a Unicode character without the given Unicode property.
+     * Invalid Unicode properties or values will cause .toRegex() to throw an error.
+     * Enables the unicode `u` flag when used.
+     * @param property A Unicode character property in the form `loneProperty` or `property=value`.
+     * For valid properties see the MDN Docs:
+     * https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape
+     */
+    notUnicodeProperty(property: string): SuperExpressive;
+
+    /**
      * Matches any character that falls between `a` and `b`. Ordering is defined by a characters ASCII or unicode value.
      */
     range(a: string, b: string): SuperExpressive;

--- a/index.d.ts
+++ b/index.d.ts
@@ -288,6 +288,12 @@ declare class SuperExpressive {
     hexCode(hex: string): SuperExpressive;
 
     /**
+     * Matches a UTF-16 code unit with the code `hex`.
+     * @param hex A 4 digit hexadecimal string.
+     */
+    utf16Code(hex: string): SuperExpressive;
+
+    /**
      * Matches any character that falls between `a` and `b`. Ordering is defined by a characters ASCII or unicode value.
      */
     range(a: string, b: string): SuperExpressive;

--- a/index.d.ts
+++ b/index.d.ts
@@ -282,6 +282,12 @@ declare class SuperExpressive {
     controlChar(c: string): SuperExpressive;
 
     /**
+     * Matches a character with the code `hex`.
+     * @param hex A 2 digit hexadecimal string.
+     */
+    hexCode(hex: string): SuperExpressive;
+
+    /**
      * Matches any character that falls between `a` and `b`. Ordering is defined by a characters ASCII or unicode value.
      */
     range(a: string, b: string): SuperExpressive;

--- a/index.js
+++ b/index.js
@@ -80,6 +80,9 @@ const t = {
   newline: asType('newline',{ classCompatible: true }) (),
   carriageReturn: asType('carriageReturn', { classCompatible: true }) (),
   tab: asType('tab', { classCompatible: true }) (),
+  verticalTab: asType('verticalTab', { classCompatible: true }) (),
+  formFeed: asType('formFeed', { classCompatible: true }) (),
+  backspace: asType('backspace', { classCompatible: true }) (),
   nullByte: asType('nullByte', { classCompatible: true }) (),
   anyOfChars: asType('anyOfChars', { classCompatible: true }),
   anythingButString: asType('anythingButString'),
@@ -118,10 +121,13 @@ const fuseElements = elements => {
   const fused = fusables.map(el => {
     if (el.type === 'char' || el.type === 'anyOfChars') {
       return el.value;
-    } else if (el.type !== 'range') {
-      return SuperExpressive[evaluate](el);
+    } else if (el.type === 'range') {
+      return `${el.value[0]}-${el.value[1]}`
+    } else if (el.type === 'backspace') {
+      return `\\b`;
     }
-    return `${el.value[0]}-${el.value[1]}`;
+
+    return SuperExpressive[evaluate](el);;
   }).join('');
   return [fused, rest];
 }
@@ -214,6 +220,9 @@ class SuperExpressive {
   get newline() { return this[matchElement](t.newline); }
   get carriageReturn() { return this[matchElement](t.carriageReturn); }
   get tab() { return this[matchElement](t.tab); }
+  get verticalTab() { return this[matchElement](t.verticalTab); }
+  get formFeed() { return this[matchElement](t.formFeed); }
+  get backspace() { return this[matchElement](t.backspace); }
   get nullByte() { return this[matchElement](t.nullByte); }
 
   namedBackreference(name) {
@@ -649,6 +658,9 @@ class SuperExpressive {
       case 'newline': return '\\n';
       case 'carriageReturn': return '\\r';
       case 'tab': return '\\t';
+      case 'verticalTab': return '\\v';
+      case 'formFeed': return '\\f';
+      case 'backspace': return '[\\b]';
       case 'nullByte': return '\\0';
       case 'string': return el.value;
       case 'char': return el.value;

--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ const t = {
   string: asType('string', { quantifierRequiresGroup: true }),
   controlChar: asType('controlChar', { classCompatible: true }),
   hexCode: asType('hexCode', { classCompatible: true }),
+  utf16Code: asType('utf16Code', { classCompatible: true }),
   namedBackreference: name => deferredType('namedBackreference', { name }),
   backreference: index => deferredType('backreference', { index }),
   capture: deferredType('capture', { containsChildren: true }),
@@ -481,6 +482,18 @@ class SuperExpressive {
     return next;
   }
 
+  utf16Code(hex) {
+    assert(typeof hex === 'string', `hex must be a string (got ${hex})`);
+    assert(hex.length === 4, `utf16Code() can only be called with a 4 character string (got ${hex})`);
+    assert(hexadecimalStringRegex.test(hex), `hex can only contain hexadecimal characters (got ${hex})`);
+
+    const next = this[clone]();
+    const currentFrame = next[getCurrentFrame]();
+    currentFrame.elements.push(next[applyQuantifier](t.utf16Code(hex)));
+
+    return next;
+  }
+
   range(a, b) {
     const strA = a.toString();
     const strB = b.toString();
@@ -693,6 +706,7 @@ class SuperExpressive {
       case 'char': return el.value;
       case 'controlChar': return `\\c${el.value}`;
       case 'hexCode': return `\\x${el.value}`;
+      case 'utf16Code': return `\\u${el.value}`;
       case 'range': return `[${el.value[0]}-${el.value[1]}]`;
       case 'anythingButRange': return `[^${el.value[0]}-${el.value[1]}]`;
       case 'anyOfChars': return `[${el.value}]`;

--- a/index.test.js
+++ b/index.test.js
@@ -271,6 +271,18 @@ describe('SuperExpressive', () => {
     () => SuperExpressive().controlChar('~')
   );
 
+  testRegexEquality('hexCode', /\x21/, SuperExpressive().hexCode('21'));
+  testErrorConditition(
+    'hexCode: only one digit',
+    'hexCode() can only be called with a 2 character string (got a)',
+    () => SuperExpressive().hexCode('a')
+  );
+  testErrorConditition(
+    'hexCode: invalid characters',
+    'hex can only contain hexadecimal characters (got ak)',
+    () => SuperExpressive().hexCode('ak')
+  );
+
   testRegexEquality('range', /[a-z]/, SuperExpressive().range('a', 'z'));
 });
 

--- a/index.test.js
+++ b/index.test.js
@@ -283,6 +283,18 @@ describe('SuperExpressive', () => {
     () => SuperExpressive().hexCode('ak')
   );
 
+  testRegexEquality('utf16Code', /\u0021/, SuperExpressive().utf16Code('0021'));
+  testErrorConditition(
+    'utf16Code: only one digit',
+    'utf16Code() can only be called with a 4 character string (got a)',
+    () => SuperExpressive().utf16Code('a')
+  );
+  testErrorConditition(
+    'utf16Code: invalid characters',
+    'hex can only contain hexadecimal characters (got 0A2K)',
+    () => SuperExpressive().utf16Code('0A2K')
+  );
+
   testRegexEquality('range', /[a-z]/, SuperExpressive().range('a', 'z'));
 });
 

--- a/index.test.js
+++ b/index.test.js
@@ -259,6 +259,18 @@ describe('SuperExpressive', () => {
     () => SuperExpressive().char('hello')
   );
 
+  testRegexEquality('controlChar', /\cM/, SuperExpressive().controlChar('m'));
+  testErrorConditition(
+    'controlChar: more than one',
+    'controlChar() can only be called with a single character from a-z (got aa)',
+    () => SuperExpressive().controlChar('aa')
+  );
+  testErrorConditition(
+    'controlChar: invalid character',
+    'controlChar() can only be called with a single character from a-z (got ~)',
+    () => SuperExpressive().controlChar('~')
+  );
+
   testRegexEquality('range', /[a-z]/, SuperExpressive().range('a', 'z'));
 });
 

--- a/index.test.js
+++ b/index.test.js
@@ -295,6 +295,48 @@ describe('SuperExpressive', () => {
     () => SuperExpressive().utf16Code('0A2K')
   );
 
+  testRegexEquality('unicodeCharCode', /\u{00021}/u, SuperExpressive().unicodeCharCode('00021'));
+  testErrorConditition(
+    'unicodeCharCode: only one digit',
+    'unicodeCharCode() can only be called with a 4 or 5 character string (got a)',
+    () => SuperExpressive().unicodeCharCode('a')
+  );
+  testErrorConditition(
+    'unicodeCharCode: invalid characters',
+    'hex can only contain hexadecimal characters (got 00A2K)',
+    () => SuperExpressive().unicodeCharCode('00A2K')
+  );
+
+  testRegexEquality('unicodeProperty', /\p{Script=Latin}/u, SuperExpressive().unicodeProperty('Script=Latin'));
+  testRegexEquality('unicodeProperty: lone property', /\p{L}/u, SuperExpressive().unicodeProperty('L'));
+  testErrorConditition(
+    'unicodeProperty: invalid characters',
+    `Property is not a valid Unicode property (got ~). ` +
+    `For valid properties see: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape`,
+    () => SuperExpressive().unicodeProperty('~')
+  );
+  testErrorConditition(
+    'unicodeProperty: invalid property name',
+    `Property is not a valid Unicode property (got nope). ` +
+    `For valid properties see: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape`,
+    () => SuperExpressive().unicodeProperty('nope')
+  );
+
+  testRegexEquality('notUnicodeProperty', /\P{Script=Latin}/u, SuperExpressive().notUnicodeProperty('Script=Latin'));
+  testRegexEquality('notUnicodeProperty: lone property', /\P{L}/u, SuperExpressive().notUnicodeProperty('L'));
+  testErrorConditition(
+    'notUnicodeProperty: invalid characters',
+    `Property is not a valid Unicode property (got ~). ` +
+    `For valid properties see: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape`,
+    () => SuperExpressive().notUnicodeProperty('~')
+  );
+  testErrorConditition(
+    'notUnicodeProperty: invalid property name',
+    `Property is not a valid Unicode property (got nope). ` +
+    `For valid properties see: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape`,
+    () => SuperExpressive().notUnicodeProperty('nope')
+  );
+
   testRegexEquality('range', /[a-z]/, SuperExpressive().range('a', 'z'));
 });
 

--- a/index.test.js
+++ b/index.test.js
@@ -42,6 +42,10 @@ describe('SuperExpressive', () => {
   testRegexEquality('newline', /\n/, SuperExpressive().newline);
   testRegexEquality('carriageReturn', /\r/, SuperExpressive().carriageReturn);
   testRegexEquality('tab', /\t/, SuperExpressive().tab);
+  testRegexEquality('verticalTab', /\v/, SuperExpressive().verticalTab);
+  testRegexEquality('formFeed', /\f/, SuperExpressive().formFeed);
+  testRegexEquality('backspace', /[\b]/, SuperExpressive().backspace);
+  testRegexEquality('backspace fused', /[\b]/, SuperExpressive().anyOf.backspace.end());
   testRegexEquality('nullByte', /\0/, SuperExpressive().nullByte);
 
   testRegexEquality(

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,9 @@
   - [.controlChar(c)](#controlCharc)
   - [.hexCode(hex)](#hexCodehex)
   - [.utf16Code(hex)](#utf16Codehex)
+  - [.unicodeCharCode(hex)](#unicodeCharCodehex)
+  - [.unicodeProperty(property)](#unicodePropertyproperty)
+  - [.notUnicodeProperty(property)](#notUnicodePropertyproperty)
   - [.range(a, b)](#rangea-b)
   - [.subexpression(expr, opts)](#subexpressionexpr-opts)
   - [.toRegexString()](#toRegexString)
@@ -900,6 +903,50 @@ SuperExpressive()
   .toRegex();
 // ->
 /\u002A/
+```
+
+### .unicodeCharCode(hex)
+
+Matches a Unicode character code with the value `hex`, where `hex` is a 4 or 5 digit hexadecimal string.
+Implicitly enables the `u` flag on the regular expression.
+
+**Example**
+```JavaScript
+SuperExpressive()
+  .unicodeCharCode('0002A')
+  .toRegex();
+// ->
+/\u{0002A}/u
+```
+
+### .unicodeProperty(property)
+
+Matches a Unicode character with the given Unicode property.
+See the [MDN Docs](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) for valid properties.
+Implicitly enables the `u` flag on the regular expression.
+
+**Example**
+```JavaScript
+SuperExpressive()
+  .unicodeProperty('Script=Latin')
+  .toRegex();
+// ->
+/\p{Script=Latin}/u
+```
+
+### .notUnicodeProperty(property)
+
+Matches a Unicode character without the given Unicode property.
+See the [MDN Docs](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) for valid properties.
+Implicitly enables the `u` flag on the regular expression.
+
+**Example**
+```JavaScript
+SuperExpressive()
+  .notUnicodeProperty('Script=Latin')
+  .toRegex();
+// ->
+/\P{Script=Latin}/u
 ```
 
 ### .range(a, b)

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@
   - [.string(s)](#strings)
   - [.char(c)](#charc)
   - [.controlChar(c)](#controlCharc)
+  - [.hexCode(hex)](#hexCodehex)
   - [.range(a, b)](#rangea-b)
   - [.subexpression(expr, opts)](#subexpressionexpr-opts)
   - [.toRegexString()](#toRegexString)
@@ -872,6 +873,19 @@ SuperExpressive()
   .toRegex();
 // ->
 /\cJ/
+```
+
+### .hexCode(hex)
+
+Matches a character with the code `hex`, where `hex` is a 2 dogit hexadecimal string.
+
+**Example**
+```JavaScript
+SuperExpressive()
+  .hexCode('2A')
+  .toRegex();
+// ->
+/\x2A/
 ```
 
 ### .range(a, b)

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@
   - [.char(c)](#charc)
   - [.controlChar(c)](#controlCharc)
   - [.hexCode(hex)](#hexCodehex)
+  - [.utf16Code(hex)](#utf16Codehex)
   - [.range(a, b)](#rangea-b)
   - [.subexpression(expr, opts)](#subexpressionexpr-opts)
   - [.toRegexString()](#toRegexString)
@@ -886,6 +887,19 @@ SuperExpressive()
   .toRegex();
 // ->
 /\x2A/
+```
+
+### .utf16Code(hex)
+
+Matches a UTF-16 code unit with the code `hex`, where `hex` is a 4 digit hexadecimal string.
+
+**Example**
+```JavaScript
+SuperExpressive()
+  .utf16Code('002A')
+  .toRegex();
+// ->
+/\u002A/
 ```
 
 ### .range(a, b)

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@
   - [.anythingButRange(a, b)](#anythingButRangea-b)
   - [.string(s)](#strings)
   - [.char(c)](#charc)
+  - [.controlChar(c)](#controlCharc)
   - [.range(a, b)](#rangea-b)
   - [.subexpression(expr, opts)](#subexpressionexpr-opts)
   - [.toRegexString()](#toRegexString)
@@ -858,6 +859,19 @@ SuperExpressive()
   .toRegex();
 // ->
 /x/
+```
+
+### .controlChar(c)
+
+Matches a control character using carat notation (`Ctrl^c`) where `c` is a single latin letter from A-Z.
+
+**Example**
+```JavaScript
+SuperExpressive()
+  .controlChar('J')
+  .toRegex();
+// ->
+/\cJ/
 ```
 
 ### .range(a, b)

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,9 @@
   - [.newline](#newline)
   - [.carriageReturn](#carriageReturn)
   - [.tab](#tab)
+  - [.verticalTab](#verticalTab)
+  - [.formFeed](#formFeed)
+  - [.backspace](#backspace)
   - [.nullByte](#nullByte)
   - [.anyOf](#anyOf)
   - [.capture](#capture)
@@ -391,6 +394,45 @@ SuperExpressive()
   .toRegex();
 // ->
 /\t/
+```
+
+### .verticalTab
+
+Matches a `\v` character.
+
+**Example**
+```JavaScript
+SuperExpressive()
+  .verticalTab
+  .toRegex();
+// ->
+/\v/
+```
+
+### .formFeed
+
+Matches a `\f` character.
+
+**Example**
+```JavaScript
+SuperExpressive()
+  .formFeed
+  .toRegex();
+// ->
+/\f/
+```
+
+### .backspace
+
+Matches a `\b` character.
+
+**Example**
+```JavaScript
+SuperExpressive()
+  .backspace
+  .toRegex();
+// ->
+/[\b]/
 ```
 
 ### .nullByte


### PR DESCRIPTION
<!--

Thanks for taking an interest in this project, and the time to open a pull request!
Please use the following checklist to guide the process. If the checklist isn't able to fully convey your
intentions then feel free to leave elaboration comments below!

-->

## Adds support for all missing JavaScript Regex character classes

- [ ] This PR  only introduces changes to documentation.
  - Please include a summary of changes and an explanation
- [x] This PR adds new functionality
  - [x] Is there a related issue?
    - Please note the related issue below, and how this PR relates to the issue if appropriate
  - [x] Does the code style reasonably match the existing code?
  - [x] Are the changes tested (using the existing format, as far as is possible?)
  - [x] Are the changes documented in the readme with a suitable example?
  - [x] Is the table of contents updated?
  - [x] Is the `index.d.ts` file updated, using appropriate types and using the same description as the readme?
- [ ] This PR introduces some other kind of change
  - Please explain the change below

This PR adds support for all remaining character classes as specified in the [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes). This PR builds on top of PR #67. May partially address #62.

The new additions are:

**.verticalTab** - `\v`.

**.formFeed** - `\f`.

**.backspace** - `\b` (evaluates to `[\b]` when not fused).

**.controlChar(X)** - `\cX` where `X` is a one digit letter from `A-Z`.

**.hexCode(HH)** - `\xHH` where `HH` is a 2 digit hexadecimal string.

**.utf16Code(HHHH)** - `\uHHHH` where `HHHH` is a 4 digit hexadecimal string.

**.unicodeCharCode(HHHHH)** - `\u{HHHH}` where `HHHHH` is a 4 or 5 digit hexadecimal string. Enables the `u` flag automatically.

**.unicodeProperty(property)** - `\p{property}` where `property` is a Unicode Character Property. Enables the `u` flag automatically.

**.notUnicodeProperty(property)** - `\P{property}` where `property` is a Unicode Character Property. Enables the `u` flag automatically.


All methods which take input are checking that the input is the correct type, length, and consists of the correct characters, and are throwing errors correctly when the input is invalid. The `.unicodeProperties()` function attempts to compile the given property into a RegExp object to test if the property is valid. If this is not done the error will only be thrown when the `.toRegex()` method is called, better I think to throw immediately. I can also split this into multiple PRs if you prefer.

Feel free to dictate any changes to method names, documentation, or behaviour.