### PR TITLE
adds full unicode support for .range() (#62)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -263,6 +263,7 @@ declare class SuperExpressive {
 
     /**
      * Matches any character that falls between `a` and `b`. Ordering is defined by a characters ASCII or unicode value.
+     * The `u` flag is automatically enabled if either `a` or `b` are unicode characters larger than 2 bytes.
      */
     range(a: string, b: string): SuperExpressive;
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ const replaceAll = (s, find, replace) => s.replace(new RegExp(`\\${find}`, 'g'),
 const escapeSpecial = s => specialChars.reduce((acc, char) => replaceAll(acc, char, `\\${char}`), s);
 
 const namedGroupRegex = /^[a-z]+\w*$/i;
+const singleUnicodeCharRegex = /^[^]$/u;
 
 const quantifierTable = {
   oneOrMore: '+',
@@ -449,14 +450,18 @@ class SuperExpressive {
     const strA = a.toString();
     const strB = b.toString();
 
-    assert(strA.length === 1, `a must be a single character or number (got ${strA})`);
-    assert(strB.length === 1, `b must be a single character or number (got ${strB})`);
-    assert(strA.charCodeAt(0) < strB.charCodeAt(0), `a must have a smaller character value than b (a = ${strA.charCodeAt(0)}, b = ${strB.charCodeAt(0)})`);
+    assert(singleUnicodeCharRegex.test(strA), `a must be a single character or number (got ${strA})`);
+    assert(singleUnicodeCharRegex.test(strB), `b must be a single character or number (got ${strB})`);
+    assert(strA.codePointAt(0) < strB.codePointAt(0), `a must have a smaller character value than b (a = ${strA.codePointAt(0)}, b = ${strB.codePointAt(0)})`);
 
     const next = this[clone]();
 
     const elementValue = t.range([strA, strB]);
     const currentFrame = next[getCurrentFrame]();
+
+    if (strA.length > 1 || strB.length > 1) {
+      next.state.flags.u = true;
+    }
 
     currentFrame.elements.push(next[applyQuantifier](elementValue));
 

--- a/index.test.js
+++ b/index.test.js
@@ -256,6 +256,23 @@ describe('SuperExpressive', () => {
   );
 
   testRegexEquality('range', /[a-z]/, SuperExpressive().range('a', 'z'));
+  testRegexEquality('range: unicode',/[a-z😀-😆]/u,
+    SuperExpressive()
+      .anyOf
+        .range('a','z')
+        .range('\u{1F600}', '\u{1F606}')
+      .end()
+  );
+  testErrorConditition(
+    'range: more than single characters',
+    'a must be a single character or number (got aa)',
+    () => SuperExpressive().range('aa','b')
+  );
+  testErrorConditition(
+    'range: more than single unicode character',
+    'b must be a single character or number (got ❤❤)',
+    () => SuperExpressive().range('a','❤❤')
+  );
 });
 
 describe('subexpressions', () => {

--- a/readme.md
+++ b/readme.md
@@ -821,14 +821,16 @@ SuperExpressive()
 ### .range(a, b)
 
 Matches any character that falls between `a` and `b`. Ordering is defined by a characters ASCII or unicode value.
+The `u` flag is automatically enabled if either `a` or `b` are unicode characters larger than 2 bytes.
 
 **Example**
 ```JavaScript
 SuperExpressive()
   .range('a', 'z')
+  .range('\u{1F600}', '\u{1F606}')
   .toRegex();
 // ->
-/[a-z]/
+/[a-z][😀-😆]/u
 ```
 
 ### .subexpression(expr, opts?)


### PR DESCRIPTION
<!--

Thanks for taking an interest in this project, and the time to open a pull request!
Please use the following checklist to guide the process. If the checklist isn't able to fully convey your
intentions then feel free to leave elaboration comments below!

-->

## Adds full Unicode support to the `range()` method

- [ ] This PR  only introduces changes to documentation.
  - Please include a summary of changes and an explanation
- [x] This PR adds new functionality
  - [x] Is there a related issue?
    - Please note the related issue below, and how this PR relates to the issue if appropriate
  - [x] Does the code style reasonably match the existing code?
  - [x] Are the changes tested (using the existing format, as far as is possible?)
  - [x] Are the changes documented in the readme with a suitable example?
  - [x] Is the table of contents updated?
  - [x] Is the `index.d.ts` file updated, using appropriate types and using the same description as the readme?
- [ ] This PR introduces some other kind of change
  - Please explain the change below

This commit allows full Unicode characters to be given to the range function. The method still correctly throws an error when more than a single character is passed as an argument, but now it will read a 4 byte Unicode character as one character instead of two.

If either `a` or `b` are unicode characters larger than 2 bytes the `u` flag is added automatically.

Partially addresses #62 