### PR TITLE
add `atLeastLazy` method (#40)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -232,6 +232,11 @@ declare class SuperExpressive {
     atLeast(n: number): SuperExpressive;
 
     /**
+     * Assert that the proceeding element will be matched at least `n` times, but as few times as possible.
+     */
+    atLeastLazy(n: number): SuperExpressive;
+
+    /**
      * Assert that the proceeding element will be matched somewhere between `x` and `y` times.
      */
     between(x: number, y: number): SuperExpressive;

--- a/index.test.js
+++ b/index.test.js
@@ -289,6 +289,7 @@ describe('SuperExpressive', () => {
   testRegexEquality('oneOrMoreLazy', /\w+?/, SuperExpressive().oneOrMoreLazy.word);
   testRegexEquality('exactly', /\w{4}/, SuperExpressive().exactly(4).word);
   testRegexEquality('atLeast', /\w{4,}/, SuperExpressive().atLeast(4).word);
+  testRegexEquality('atLeastLazy', /\w{4,}?/, SuperExpressive().atLeastLazy(4).word);
   testRegexEquality('between', /\w{4,7}/, SuperExpressive().between(4, 7).word);
   testRegexEquality('betweenLazy', /\w{4,7}?/, SuperExpressive().betweenLazy(4, 7).word);
 

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@
   - [.oneOrMoreLazy](#oneOrMoreLazy)
   - [.exactly(n)](#exactlyn)
   - [.atLeast(n)](#atLeastn)
+  - [.atLeastLazy(n)](#atLeastLazyn)
   - [.between(x, y)](#betweenx-y)
   - [.betweenLazy(x, y)](#betweenLazyx-y)
   - [.startOfInput](#startOfInput)
@@ -733,6 +734,19 @@ SuperExpressive()
   .toRegex();
 // ->
 /\d{5,}/
+```
+
+### .atLeastLazy(n)
+
+Assert that the proceeding element will be matched at least `n` times, but as few times as possible.
+
+**Example**
+```JavaScript
+SuperExpressive()
+  .atLeastLazy(5).digit
+  .toRegex();
+// ->
+/\d{5,}?/
 ```
 
 ### .between(x, y)


### PR DESCRIPTION
<!--

Thanks for taking an interest in this project, and the time to open a pull request!
Please use the following checklist to guide the process. If the checklist isn't able to fully convey your
intentions then feel free to leave elaboration comments below!

-->

## Add the `atleastLazy` method

- [ ] This PR  only introduces changes to documentation.
  - Please include a summary of changes and an explanation
- [x] This PR adds new functionality
  - [x] Is there a related issue?
    - Please note the related issue below, and how this PR relates to the issue if appropriate
  - [x] Does the code style reasonably match the existing code?
  - [x] Are the changes tested (using the existing format, as far as is possible?)
  - [x] Are the changes documented in the readme with a suitable example?
  - [x] Is the table of contents updated?
  - [x] Is the `index.d.ts` file updated, using appropriate types and using the same description as the readme?
- [ ] This PR introduces some other kind of change
  - Please explain the change below

This adds a new function to implement lazy `atLeast` behaviour. This should be the last lazy quantifier (except for `exact` where a greedy modifier doesn't seem to make sense).

This should resolve #40.