### PR TITLE
fix anythingButRange range parameters type 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -269,7 +269,7 @@ declare class SuperExpressive {
     /**
      * Matches any character, except those that would be captured by the `.range` specified by `a` and `b`.
      */
-    anythingButRange(a: number, b: number): SuperExpressive;
+    anythingButRange(a: string, b: string): SuperExpressive;
 
     /**
      * Matches the exact string `s`.


### PR DESCRIPTION
## changed anythingButRange parameters to `string` following the `.range` parameters
  - The function checks for characters, not the charcodes, so the appropriate type is string, same as in the `.range` method. Check the issue bellow for examples.  
  - [ x ] Is there a related issue?
    - #75    
  - [ x ] Does the code style reasonably match the existing code?
  - [ x ] Are the changes tested (using the existing format, as far as is possible?)
  - [ x ] Is the `index.d.ts` file updated, using appropriate types and using the same description as the readme?